### PR TITLE
Fix export module object error bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var through = require('through2'),
     format = require('string-format-js');
 
-var prefix = "(function(g, f) { var r = (typeof require === 'function' ? require : function(name) { return #{depsMap}[name]; }); if (typeof exports === 'object' && typeof module !== 'undefined') { module.exports = f(r) } else if (typeof define === 'function' && define.amd) { define(#{depsKeys}, f.bind(g,r)) } else { g.#{globalName} = f(r) } })(this, function(require,define, module,exports) { return ";
+var prefix = "(function(g, f) { var r = (typeof require === 'function' ? require : function(name) { return #{depsMap}[name]; }); if (typeof exports === 'object' && typeof module !== 'undefined') { module.exports = f(r) } else if (typeof define === 'function' && define.amd) { define(#{depsKeys}, f.bind(g,r)) } else { g.#{globalName} = f(r) } })(this, function(require,define, module,exports) { var _m = ";
 
-var suffix = "(#{moduleKey}); });";
+var suffix = "return _m(#{moduleKey}); });";
 
 function createStream(prefix, suffix) {
     var first = true;


### PR DESCRIPTION
Hello, I used `dependify` in my project. Recently I found after bundled with Browserify, there has an extra semicolon caused the error.
The error is in last two lines of code:

``` js
return (function e(t, n, r) {
...
},{"nornj":"nornj"}]},{},[1]);  //there has an extra semicolon, caused the function not to be called.
(1); });
```

I changed it to:

``` js
var _m = (function e(t, n, r) {  //Save function first
...
},{"nornj":"nornj"}]},{},[1]);
return _m(1); });  //Then call it.
```

I hope you can adopt it and republish package, thanks a lot!
